### PR TITLE
fix: use direct_prompt for primordia-evolve label trigger

### DIFF
--- a/.github/workflows/evolve.yml
+++ b/.github/workflows/evolve.yml
@@ -50,10 +50,28 @@ jobs:
         with:
           fetch-depth: 1
 
+      # When triggered by the primordia-evolve label (no @claude in content),
+      # build an explicit prompt from the issue body so the action has something
+      # to work with. For @claude mention triggers this step is skipped and the
+      # action extracts the prompt from the event content itself.
+      - name: Build prompt for label trigger
+        id: label_prompt
+        if: github.event_name == 'issues' && github.event.label.name == 'primordia-evolve'
+        run: |
+          cat >> "$GITHUB_OUTPUT" <<'EOF'
+          prompt=Please implement the following change request from the issue. Read PRIMORDIA.md for full architecture context, implement the requested changes, and update the Changelog section of PRIMORDIA.md with a brief entry describing what you changed and why.
+
+          Issue title: ${{ github.event.issue.title }}
+
+          Issue body:
+          ${{ github.event.issue.body }}
+          EOF
+
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          direct_prompt: ${{ steps.label_prompt.outputs.prompt }}
           claude_args: |
             --allowedTools "Edit,Write,Read,Bash,Glob,Grep"
-            --system-prompt "You are working on Primordia, a self-modifying web application built with TypeScript, Tailwind CSS, and Next.js App Router. When implementing changes: keep them minimal and focused on the request; do not introduce new dependencies unless absolutely required; maintain the existing code style; read PRIMORDIA.md for architecture context and update its Changelog section with a brief entry describing what you changed and why."
+            --system-prompt "You are working on Primordia, a self-modifying web application built with TypeScript, Tailwind CSS, and Next.js App Router. Keep changes minimal and focused on the request. Do not introduce new dependencies unless absolutely required. Maintain the existing code style."


### PR DESCRIPTION
The claude-code-action internally checks for @claude in the event content. When triggered by a label there is no such mention, so it exits with 'NO PROMPT'. Pass direct_prompt (built from the issue body) for the label trigger so the action skips its trigger detection and runs with an explicit prompt.