### PR TITLE
fix: bold text rendered twice in SimpleMarkdown

### DIFF
--- a/PRIMORDIA.md
+++ b/PRIMORDIA.md
@@ -159,6 +159,14 @@ These were noted at project inception but are explicitly out of scope for the MV
 
 ## Changelog
 
+### 2026-03-14 — Fix bold text duplication in SimpleMarkdown
+
+**What changed**: Fixed a bug in `SimpleMarkdown` where bold text (`**text**`) was rendered twice — once as a `<strong>` element and once as a plain `<span>`.
+
+**Why**: `String.split()` with a regex that has capturing groups includes those captured sub-groups in the result array. The split regex had inner capturing groups (e.g., `([^*]+)` inside `\*\*([^*]+)\*\*`), so for each bold token the array contained both the full `**text**` match and the inner `text` capture. The fix converts all inner groups to non-capturing (`(?:...)`) so only the full token appears in the split result.
+
+---
+
 ### 2026-03-14 — Initial Scaffold
 
 **What changed**: Built the entire initial scaffold from scratch.

--- a/components/ChatInterface.tsx
+++ b/components/ChatInterface.tsx
@@ -326,8 +326,11 @@ function MessageBubble({ message }: { message: Message }) {
 function SimpleMarkdown({ text }: { text: string }) {
   if (!text) return null;
 
-  // Split on links [text](url), bold **text**, and inline `code`
-  const parts = text.split(/(\[([^\]]+)\]\(([^)]+)\)|\*\*([^*]+)\*\*|`([^`]+)`)/g);
+  // Split on links [text](url), bold **text**, and inline `code`.
+  // Use non-capturing inner groups so split() only puts the full token in the
+  // array — not each inner capture group — which would otherwise cause bold
+  // text to be rendered twice (once as <strong>, once as a plain <span>).
+  const parts = text.split(/(\[(?:[^\]]+)\]\((?:[^)]+)\)|\*\*(?:[^*]+)\*\*|`(?:[^`]+)`)/g);
 
   const rendered: React.ReactNode[] = [];
   let i = 0;


### PR DESCRIPTION
Fixes #7

Bold text (`**text**`) was rendered twice — once as `<strong>` and once as a plain `<span>` — because `String.split()` with capturing groups includes inner capture groups in the result array. Fixed by making inner groups non-capturing.

Generated with [Claude Code](https://claude.ai/code)