### PR TITLE
feat: poll GitHub CI pipeline and surface evolve progress in chat

### DIFF
--- a/PRIMORDIA.md
+++ b/PRIMORDIA.md
@@ -51,7 +51,9 @@ primordia/
 │       ├── chat/
 │       │   └── route.ts           ← Streams Claude responses via SSE
 │       └── evolve/
-│           └── route.ts           ← Creates a labeled GitHub Issue
+│           ├── route.ts           ← Creates a labeled GitHub Issue
+│           └── status/
+│               └── route.ts      ← Polls GitHub for issue comment, PR, deploy preview
 │
 ├── components/
 │   ├── ChatInterface.tsx          ← Main chat UI; handles chat + evolve modes
@@ -158,6 +160,18 @@ These were noted at project inception but are explicitly out of scope for the MV
 ---
 
 ## Changelog
+
+### 2026-03-14 — Evolve pipeline feedback loop in chat
+
+**What changed**: After an evolve request is submitted, the Primordia chat now automatically tracks CI progress and surfaces updates without requiring the user to leave the page.
+
+**New**: `app/api/evolve/status/route.ts` — a `GET /api/evolve/status?issueNumber=N` endpoint that polls three GitHub API resources: (1) issue comments to find Claude's response comment, (2) open/recent PRs whose branch matches `claude/issue-{N}-*`, and (3) PR comments to find the Vercel deploy preview URL posted by the Vercel GitHub bot.
+
+**Modified**: `components/ChatInterface.tsx` — after a successful evolve submit, starts polling `/api/evolve/status` every 10 seconds (up to 15 min). When each milestone is detected it appends a chat message: Claude's initial response (first 400 chars + link), the PR link, and finally the deploy preview URL. Polling stops when the deploy preview is found or the timeout is reached. A "Watching CI pipeline…" indicator is shown while polling.
+
+**Why**: Users had to manually navigate to GitHub to see whether the CI pipeline had responded to their evolve request. This closes the loop so everything — request, Claude response, PR, and live preview — is visible within the Primordia chat.
+
+---
 
 ### 2026-03-14 — Fix bold text duplication in SimpleMarkdown
 

--- a/app/api/evolve/status/route.ts
+++ b/app/api/evolve/status/route.ts
@@ -1,0 +1,159 @@
+// app/api/evolve/status/route.ts
+// Polls GitHub for the current status of an evolve issue:
+//   - Claude's comment on the issue (the claude-code-action response)
+//   - The PR auto-created for the issue (branch naming: claude/issue-{N}-*)
+//   - The Vercel deploy preview URL posted as a PR comment
+//
+// GET /api/evolve/status?issueNumber=N
+//
+// Response (JSON):
+//   {
+//     claudeComment:    string | null,   // body of Claude's issue comment
+//     claudeCommentUrl: string | null,   // link to view Claude's comment on GitHub
+//     prNumber:         number | null,
+//     prUrl:            string | null,
+//     deployPreviewUrl: string | null,
+//   }
+//
+// Required environment variables:
+//   GITHUB_TOKEN  — personal access token with repo + issues read access
+//   GITHUB_REPO   — "owner/repo" string
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const issueNumberStr = searchParams.get("issueNumber");
+
+  if (!issueNumberStr) {
+    return Response.json(
+      { error: "issueNumber query param required" },
+      { status: 400 }
+    );
+  }
+
+  const issueNumber = parseInt(issueNumberStr, 10);
+  if (isNaN(issueNumber)) {
+    return Response.json(
+      { error: "issueNumber must be a number" },
+      { status: 400 }
+    );
+  }
+
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPO;
+
+  if (!token || !repo) {
+    return Response.json(
+      { error: "GITHUB_TOKEN and GITHUB_REPO environment variables are required" },
+      { status: 500 }
+    );
+  }
+
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+
+  try {
+    // 1. Fetch issue comments — find Claude's response comment
+    const commentsRes = await fetch(
+      `https://api.github.com/repos/${repo}/issues/${issueNumber}/comments`,
+      { headers }
+    );
+    if (!commentsRes.ok) {
+      throw new Error(`GitHub API error ${commentsRes.status} fetching issue comments`);
+    }
+    const issueComments = (await commentsRes.json()) as GitHubComment[];
+    const claudeComment = findClaudeComment(issueComments);
+
+    // 2. Find the PR created for this issue
+    // The claude-code-action names branches: claude/issue-{N}-{date}-{time}
+    const prsRes = await fetch(
+      `https://api.github.com/repos/${repo}/pulls?state=all&per_page=30&sort=created&direction=desc`,
+      { headers }
+    );
+    if (!prsRes.ok) {
+      throw new Error(`GitHub API error ${prsRes.status} fetching PRs`);
+    }
+    const prs = (await prsRes.json()) as GitHubPR[];
+    const matchedPR = prs.find(
+      (pr) =>
+        pr.head.ref.startsWith(`claude/issue-${issueNumber}-`) ||
+        pr.head.ref === `claude/issue-${issueNumber}`
+    );
+
+    // 3. If a PR exists, look for Vercel's deploy preview comment
+    let deployPreviewUrl: string | null = null;
+    if (matchedPR) {
+      const prCommentsRes = await fetch(
+        `https://api.github.com/repos/${repo}/issues/${matchedPR.number}/comments`,
+        { headers }
+      );
+      if (prCommentsRes.ok) {
+        const prComments = (await prCommentsRes.json()) as GitHubComment[];
+        deployPreviewUrl = findVercelPreviewUrl(prComments);
+      }
+    }
+
+    return Response.json({
+      claudeComment: claudeComment?.body ?? null,
+      claudeCommentUrl: claudeComment?.html_url ?? null,
+      prNumber: matchedPR?.number ?? null,
+      prUrl: matchedPR?.html_url ?? null,
+      deployPreviewUrl,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Failed to fetch status";
+    return Response.json({ error: msg }, { status: 500 });
+  }
+}
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface GitHubComment {
+  id: number;
+  body: string;
+  html_url: string;
+  user: { login: string; type: string };
+}
+
+interface GitHubPR {
+  number: number;
+  html_url: string;
+  head: { ref: string };
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+// The claude-code-action posts a comment that contains "Claude Code is working"
+// or a "View job run" link. It may be posted by github-actions[bot] or the PAT owner.
+function findClaudeComment(comments: GitHubComment[]): GitHubComment | null {
+  for (const comment of comments) {
+    if (
+      comment.body.includes("Claude Code is working") ||
+      comment.body.includes("View job run") ||
+      comment.body.includes("actions/runs")
+    ) {
+      return comment;
+    }
+  }
+  return null;
+}
+
+// Vercel's GitHub bot posts a comment containing the preview URL.
+// The URL pattern is typically: https://<project>-<hash>.vercel.app
+function findVercelPreviewUrl(comments: GitHubComment[]): string | null {
+  for (const comment of comments) {
+    const isVercelComment =
+      comment.user.login.toLowerCase().includes("vercel") ||
+      comment.body.toLowerCase().includes("vercel") ||
+      comment.body.includes("Deploy Preview");
+
+    if (isVercelComment) {
+      // Try to extract a vercel.app URL from the comment body
+      const match = comment.body.match(/https:\/\/[^\s)<>"]+\.vercel\.app[^\s)<>"']*/);
+      if (match) return match[0];
+    }
+  }
+  return null;
+}

--- a/components/ChatInterface.tsx
+++ b/components/ChatInterface.tsx
@@ -5,6 +5,12 @@
 //   - "chat" mode: streams responses from Claude via /api/chat
 //   - "evolve" mode: submits a GitHub Issue via /api/evolve, triggering the CI pipeline
 //
+// After an evolve issue is created, the component polls /api/evolve/status every 10s
+// and adds chat messages when:
+//   - Claude's comment appears on the issue (shows a summary + link)
+//   - A PR is created (shows PR link)
+//   - A Vercel deploy preview URL becomes available (shows preview link)
+//
 // The mode toggle is always visible so users can switch without losing their draft message.
 
 import { useState, useRef, useEffect, FormEvent } from "react";
@@ -24,6 +30,28 @@ interface EvolveResult {
   issueUrl: string;
 }
 
+interface EvolveStatus {
+  claudeComment: string | null;
+  claudeCommentUrl: string | null;
+  prNumber: number | null;
+  prUrl: string | null;
+  deployPreviewUrl: string | null;
+}
+
+// Mutable ref tracking what has already been surfaced in chat for a given issue,
+// to avoid duplicate messages across poll ticks.
+interface EvolveTracker {
+  issueNumber: number;
+  startTime: number;
+  claudeShown: boolean;
+  prShown: boolean;
+  deployShown: boolean;
+}
+
+// How often to poll (ms) and when to give up (ms)
+const POLL_INTERVAL_MS = 10_000;
+const POLL_TIMEOUT_MS = 15 * 60_000; // 15 minutes
+
 // ─── Component ──────────────────────────────────────────────────────────────
 
 export default function ChatInterface() {
@@ -40,6 +68,11 @@ export default function ChatInterface() {
   const [evolveResult, setEvolveResult] = useState<EvolveResult | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Mutable tracker for evolve polling — read inside setInterval without stale closures
+  const evolveTrackerRef = useRef<EvolveTracker | null>(null);
+  // Changing this state value kicks off the polling useEffect
+  const [activeEvolveIssue, setActiveEvolveIssue] = useState<number | null>(null);
 
   // Auto-scroll to the latest message
   useEffect(() => {
@@ -58,6 +91,87 @@ export default function ChatInterface() {
   useEffect(() => {
     setEvolveResult(null);
   }, [mode]);
+
+  // ── Evolve polling ────────────────────────────────────────────────────────
+  // Runs whenever a new evolve issue number becomes active.
+  // Polls /api/evolve/status and surfaces progress as chat messages.
+
+  useEffect(() => {
+    if (activeEvolveIssue === null) return;
+
+    const interval = setInterval(async () => {
+      const tracker = evolveTrackerRef.current;
+      if (!tracker) return;
+
+      // Give up after POLL_TIMEOUT_MS
+      if (Date.now() - tracker.startTime > POLL_TIMEOUT_MS) {
+        clearInterval(interval);
+        evolveTrackerRef.current = null;
+        setActiveEvolveIssue(null);
+        return;
+      }
+
+      try {
+        const res = await fetch(
+          `/api/evolve/status?issueNumber=${tracker.issueNumber}`
+        );
+        if (!res.ok) return; // transient error — will retry
+
+        const data = (await res.json()) as EvolveStatus;
+
+        // Show Claude's comment once it appears
+        if (data.claudeComment && !tracker.claudeShown) {
+          tracker.claudeShown = true;
+          // Show the first ~400 chars of Claude's comment so the chat isn't flooded,
+          // with a link to read the full comment on GitHub.
+          const preview = data.claudeComment.slice(0, 400).trimEnd();
+          const ellipsis = data.claudeComment.length > 400 ? "…" : "";
+          const linkPart = data.claudeCommentUrl
+            ? ` [View full response](${data.claudeCommentUrl})`
+            : "";
+          setMessages((prev) => [
+            ...prev,
+            {
+              role: "assistant",
+              content: `**Claude is working on it:**\n${preview}${ellipsis}${linkPart}`,
+            },
+          ]);
+        }
+
+        // Show PR link once the PR is created
+        if (data.prUrl && !tracker.prShown) {
+          tracker.prShown = true;
+          setMessages((prev) => [
+            ...prev,
+            {
+              role: "assistant",
+              content: `PR created! [View PR #${data.prNumber}](${data.prUrl})`,
+            },
+          ]);
+        }
+
+        // Show deploy preview URL once Vercel finishes building
+        if (data.deployPreviewUrl && !tracker.deployShown) {
+          tracker.deployShown = true;
+          setMessages((prev) => [
+            ...prev,
+            {
+              role: "assistant",
+              content: `Deploy preview is ready! [Open preview](${data.deployPreviewUrl})`,
+            },
+          ]);
+          // All done — stop polling
+          clearInterval(interval);
+          evolveTrackerRef.current = null;
+          setActiveEvolveIssue(null);
+        }
+      } catch {
+        // Network hiccup — will retry on next tick
+      }
+    }, POLL_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, [activeEvolveIssue]);
 
   // ── Handlers ──────────────────────────────────────────────────────────────
 
@@ -170,7 +284,11 @@ export default function ChatInterface() {
         body: JSON.stringify({ request }),
       });
 
-      const data = (await response.json()) as { issueNumber: number; issueUrl: string; error?: string };
+      const data = (await response.json()) as {
+        issueNumber: number;
+        issueUrl: string;
+        error?: string;
+      };
 
       if (!response.ok) {
         throw new Error(data.error ?? `API error: ${response.statusText}`);
@@ -181,9 +299,19 @@ export default function ChatInterface() {
         ...prev,
         {
           role: "assistant",
-          content: `Got it! I've opened [GitHub Issue #${data.issueNumber}](${data.issueUrl}) for your request. The CI pipeline will now generate a PR with the changes. You can follow along at the link above.`,
+          content: `Got it! I've opened [GitHub Issue #${data.issueNumber}](${data.issueUrl}) for your request. I'll let you know here when Claude responds, a PR is created, and the deploy preview is ready.`,
         },
       ]);
+
+      // Start polling for CI progress
+      evolveTrackerRef.current = {
+        issueNumber: data.issueNumber,
+        startTime: Date.now(),
+        claudeShown: false,
+        prShown: false,
+        deployShown: false,
+      };
+      setActiveEvolveIssue(data.issueNumber);
     } catch (err) {
       const errorMsg =
         err instanceof Error ? err.message : "Something went wrong.";
@@ -241,6 +369,11 @@ export default function ChatInterface() {
             Opening GitHub issue…
           </div>
         )}
+        {activeEvolveIssue !== null && (
+          <div className="text-sm text-gray-500 animate-pulse">
+            Watching CI pipeline…
+          </div>
+        )}
         <div ref={messagesEndRef} />
       </div>
 
@@ -292,7 +425,7 @@ export default function ChatInterface() {
           >
             #{evolveResult.issueNumber}
           </a>{" "}
-          opened — a PR will be generated shortly.
+          opened — watching for PR and deploy preview…
         </div>
       )}
     </div>


### PR DESCRIPTION
After an evolve request creates a GitHub issue, the Primordia chat now polls for CI progress and surfaces Claude's response, the PR link, and the Vercel deploy preview URL directly in the chat.

Closes #9

Generated with [Claude Code](https://claude.ai/code)