### PR TITLE
feat: update Claude CI comment in-place as bot edits it

### DIFF
--- a/PRIMORDIA.md
+++ b/PRIMORDIA.md
@@ -159,6 +159,16 @@ These were noted at project inception but are explicitly out of scope for the MV
 
 ## Changelog
 
+### 2026-03-14 — Live CI progress in Primordia chat
+
+**What changed**:
+- New `app/api/evolve/status/route.ts` endpoint: given an issue number, fetches (a) the latest Claude bot comment body + `updated_at`, (b) any open PR whose branch matches `claude/issue-{N}-*`, and (c) a Vercel deploy preview URL from PR comments.
+- `components/ChatInterface.tsx` now starts polling that endpoint every 10 s after a successful evolve submit. A dedicated "CI Progress" message is added to the chat and **updated in-place** every time Claude's comment changes on GitHub, so users see the bot's live task-list as it ticks off items. Separate one-time messages are appended when the PR is created and when the deploy preview URL becomes available. Polling stops automatically on deploy preview or after 15 minutes.
+
+**Why**: Claude's github comment is continuously edited as CI progresses; showing only a one-time 400-char snapshot missed all the live updates. The new approach mirrors the comment in real time directly in the Primordia chat.
+
+---
+
 ### 2026-03-14 — Fix WCAG 2 AA color contrast issues
 
 **What changed**: Improved color contrast for two elements that failed the WCAG 2 AA 4.5:1 minimum ratio for normal text:

--- a/app/api/evolve/status/route.ts
+++ b/app/api/evolve/status/route.ts
@@ -1,0 +1,139 @@
+// app/api/evolve/status/route.ts
+// Polls GitHub for the live state of an evolve pipeline run.
+// Called repeatedly by the chat UI to show CI progress in real time.
+//
+// Query params:
+//   issueNumber=N  — the GitHub issue number to check
+//
+// Response (JSON):
+//   {
+//     claudeComment?: { body: string; htmlUrl: string; updatedAt: string },
+//     pr?: { number: number; htmlUrl: string; title: string },
+//     deployPreviewUrl?: string
+//   }
+//
+// Required environment variables:
+//   GITHUB_TOKEN  — personal access token with repo + issues read access
+//   GITHUB_REPO   — "owner/repo" string, e.g. "alice/primordia"
+
+interface GitHubComment {
+  id: number;
+  body: string;
+  html_url: string;
+  updated_at: string;
+  user: { login: string; type: string };
+}
+
+interface GitHubPR {
+  number: number;
+  html_url: string;
+  title: string;
+  head: { ref: string };
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const issueNumber = parseInt(searchParams.get("issueNumber") ?? "", 10);
+
+  if (isNaN(issueNumber)) {
+    return Response.json(
+      { error: "issueNumber query param required" },
+      { status: 400 }
+    );
+  }
+
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPO;
+
+  if (!token || !repo) {
+    return Response.json(
+      { error: "GITHUB_TOKEN and GITHUB_REPO environment variables are required" },
+      { status: 500 }
+    );
+  }
+
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+
+  // ── 1. Fetch issue comments — find Claude's comment ──────────────────────
+
+  let claudeComment:
+    | { body: string; htmlUrl: string; updatedAt: string }
+    | undefined;
+
+  const commentsRes = await fetch(
+    `https://api.github.com/repos/${repo}/issues/${issueNumber}/comments?per_page=50`,
+    { headers }
+  );
+
+  if (commentsRes.ok) {
+    const comments = (await commentsRes.json()) as GitHubComment[];
+
+    // Claude's comment is posted by a Bot user or a user whose login contains
+    // "claude". The claude-code-action posts under whichever account is
+    // configured, but it's always distinct from the human issue author.
+    const claudeCommentRaw = comments.find(
+      (c) =>
+        c.user.type === "Bot" ||
+        c.user.login.toLowerCase().includes("claude")
+    );
+
+    if (claudeCommentRaw) {
+      claudeComment = {
+        body: claudeCommentRaw.body,
+        htmlUrl: claudeCommentRaw.html_url,
+        updatedAt: claudeCommentRaw.updated_at,
+      };
+    }
+  }
+
+  // ── 2. Find the PR for this issue (branch: claude/issue-{N}-*) ───────────
+
+  let pr: { number: number; htmlUrl: string; title: string } | undefined;
+  let deployPreviewUrl: string | undefined;
+
+  const prsRes = await fetch(
+    `https://api.github.com/repos/${repo}/pulls?state=open&per_page=30`,
+    { headers }
+  );
+
+  if (prsRes.ok) {
+    const prs = (await prsRes.json()) as GitHubPR[];
+
+    const matchingPr = prs.find((p) =>
+      p.head.ref.includes(`issue-${issueNumber}-`)
+    );
+
+    if (matchingPr) {
+      pr = {
+        number: matchingPr.number,
+        htmlUrl: matchingPr.html_url,
+        title: matchingPr.title,
+      };
+
+      // ── 3. Scan PR comments for a Vercel deploy preview URL ─────────────
+
+      const prCommentsRes = await fetch(
+        `https://api.github.com/repos/${repo}/issues/${matchingPr.number}/comments?per_page=30`,
+        { headers }
+      );
+
+      if (prCommentsRes.ok) {
+        const prComments = (await prCommentsRes.json()) as GitHubComment[];
+
+        for (const comment of prComments) {
+          const match = comment.body.match(/https:\/\/[\w-]+\.vercel\.app/);
+          if (match) {
+            deployPreviewUrl = match[0];
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  return Response.json({ claudeComment, pr, deployPreviewUrl });
+}

--- a/components/ChatInterface.tsx
+++ b/components/ChatInterface.tsx
@@ -5,7 +5,8 @@
 //   - "chat" mode: streams responses from Claude via /api/chat
 //   - "evolve" mode: submits a GitHub Issue via /api/evolve, triggering the CI pipeline
 //
-// The mode toggle is always visible so users can switch without losing their draft message.
+// After an evolve submit, the UI polls /api/evolve/status and updates Claude's
+// CI progress comment in-place as the bot continuously edits it on GitHub.
 
 import { useState, useRef, useEffect, FormEvent } from "react";
 import ModeToggle from "./ModeToggle";
@@ -17,11 +18,19 @@ type Mode = "chat" | "evolve";
 interface Message {
   role: "user" | "assistant" | "system";
   content: string;
+  // Optional stable ID used to find and update a message in-place.
+  id?: string;
 }
 
 interface EvolveResult {
   issueNumber: number;
   issueUrl: string;
+}
+
+interface EvolveStatus {
+  claudeComment?: { body: string; htmlUrl: string; updatedAt: string };
+  pr?: { number: number; htmlUrl: string; title: string };
+  deployPreviewUrl?: string;
 }
 
 // ─── Component ──────────────────────────────────────────────────────────────
@@ -40,6 +49,8 @@ export default function ChatInterface() {
   const [evolveResult, setEvolveResult] = useState<EvolveResult | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  // Holds the active polling interval so we can cancel it on unmount or mode reset.
+  const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   // Auto-scroll to the latest message
   useEffect(() => {
@@ -58,6 +69,15 @@ export default function ChatInterface() {
   useEffect(() => {
     setEvolveResult(null);
   }, [mode]);
+
+  // Cancel any in-flight polling when the component unmounts
+  useEffect(() => {
+    return () => {
+      if (pollingIntervalRef.current !== null) {
+        clearInterval(pollingIntervalRef.current);
+      }
+    };
+  }, []);
 
   // ── Handlers ──────────────────────────────────────────────────────────────
 
@@ -170,20 +190,35 @@ export default function ChatInterface() {
         body: JSON.stringify({ request }),
       });
 
-      const data = (await response.json()) as { issueNumber: number; issueUrl: string; error?: string };
+      const data = (await response.json()) as {
+        issueNumber: number;
+        issueUrl: string;
+        error?: string;
+      };
 
       if (!response.ok) {
         throw new Error(data.error ?? `API error: ${response.statusText}`);
       }
 
       setEvolveResult({ issueNumber: data.issueNumber, issueUrl: data.issueUrl });
+
+      // Add a confirmation message and a CI-status message that will be updated in-place.
+      const statusMsgId = `evolve-status-${data.issueNumber}`;
       setMessages((prev) => [
         ...prev,
         {
           role: "assistant",
-          content: `Got it! I've opened [GitHub Issue #${data.issueNumber}](${data.issueUrl}) for your request. The CI pipeline will now generate a PR with the changes. You can follow along at the link above.`,
+          content: `Got it! I've opened [GitHub Issue #${data.issueNumber}](${data.issueUrl}) for your request. The CI pipeline is now running — progress will appear below.`,
+        },
+        {
+          role: "assistant",
+          id: statusMsgId,
+          content: "⏳ Waiting for CI to start…",
         },
       ]);
+
+      // Begin polling for CI progress
+      startEvolvePolling(data.issueNumber, statusMsgId);
     } catch (err) {
       const errorMsg =
         err instanceof Error ? err.message : "Something went wrong.";
@@ -195,6 +230,104 @@ export default function ChatInterface() {
         },
       ]);
     }
+  }
+
+  // Polls /api/evolve/status every 10 s.
+  // Updates the status message in-place each time Claude's comment changes.
+  // Appends separate one-time messages for PR creation and deploy preview.
+  function startEvolvePolling(issueNumber: number, statusMsgId: string) {
+    // Cancel any previous poll loop
+    if (pollingIntervalRef.current !== null) {
+      clearInterval(pollingIntervalRef.current);
+    }
+
+    // Mutable tracker captured by the interval closure — avoids stale state.
+    const tracker = {
+      lastCommentUpdatedAt: "",
+      prMessageAdded: false,
+      deployMessageAdded: false,
+      pollCount: 0,
+    };
+
+    const MAX_POLLS = 90; // ~15 minutes at 10 s intervals
+
+    pollingIntervalRef.current = setInterval(async () => {
+      tracker.pollCount++;
+
+      if (tracker.pollCount > MAX_POLLS) {
+        clearInterval(pollingIntervalRef.current!);
+        pollingIntervalRef.current = null;
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === statusMsgId
+              ? {
+                  ...m,
+                  content:
+                    m.content +
+                    "\n\n⚠️ Stopped watching after 15 minutes. Check GitHub for the latest status.",
+                }
+              : m
+          )
+        );
+        return;
+      }
+
+      try {
+        const res = await fetch(
+          `/api/evolve/status?issueNumber=${issueNumber}`
+        );
+        if (!res.ok) return;
+
+        const status = (await res.json()) as EvolveStatus;
+
+        // ── Update Claude's comment in-place whenever it changes ──────────
+        if (
+          status.claudeComment &&
+          status.claudeComment.updatedAt !== tracker.lastCommentUpdatedAt
+        ) {
+          tracker.lastCommentUpdatedAt = status.claudeComment.updatedAt;
+          const { body, htmlUrl } = status.claudeComment;
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.id === statusMsgId
+                ? {
+                    ...m,
+                    content: `**CI Progress** ([view on GitHub](${htmlUrl})):\n\n${body}`,
+                  }
+                : m
+            )
+          );
+        }
+
+        // ── Append a PR message once ───────────────────────────────────────
+        if (status.pr && !tracker.prMessageAdded) {
+          tracker.prMessageAdded = true;
+          setMessages((prev) => [
+            ...prev,
+            {
+              role: "assistant",
+              content: `✅ PR created: [#${status.pr!.number} — ${status.pr!.title}](${status.pr!.htmlUrl})`,
+            },
+          ]);
+        }
+
+        // ── Append a deploy preview message once, then stop polling ───────
+        if (status.deployPreviewUrl && !tracker.deployMessageAdded) {
+          tracker.deployMessageAdded = true;
+          clearInterval(pollingIntervalRef.current!);
+          pollingIntervalRef.current = null;
+          setMessages((prev) => [
+            ...prev,
+            {
+              role: "assistant",
+              content: `🚀 Deploy preview ready: [${status.deployPreviewUrl}](${status.deployPreviewUrl})`,
+            },
+          ]);
+        }
+      } catch {
+        // Silently ignore transient network errors between polls
+      }
+    }, 10_000);
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
@@ -234,7 +367,7 @@ export default function ChatInterface() {
       {/* Message list */}
       <div className="flex-1 overflow-y-auto space-y-4 pb-4">
         {messages.map((msg, i) => (
-          <MessageBubble key={i} message={msg} />
+          <MessageBubble key={msg.id ?? i} message={msg} />
         ))}
         {isLoading && mode === "evolve" && (
           <div className="text-sm text-gray-500 animate-pulse">
@@ -292,7 +425,7 @@ export default function ChatInterface() {
           >
             #{evolveResult.issueNumber}
           </a>{" "}
-          opened — a PR will be generated shortly.
+          opened — watching for CI progress, PR, and deploy preview…
         </div>
       )}
     </div>


### PR DESCRIPTION
After an evolve issue is created, the Primordia chat polls `/api/evolve/status` every 10 s and updates the "CI Progress" message in-place each time Claude's GitHub comment changes. This surfaces the bot's live progress checklist in real time.

Closes #9

Generated with [Claude Code](https://claude.ai/code)