### PR TITLE
feat: show PR link in header on Vercel preview deployments

### DIFF
--- a/PRIMORDIA.md
+++ b/PRIMORDIA.md
@@ -159,6 +159,14 @@ These were noted at project inception but are explicitly out of scope for the MV
 
 ## Changelog
 
+### 2026-03-14 — Fix Vercel env var name for PR ID
+
+**What changed**: Renamed `VERCEL_GIT_PULL_REQUEST_NUMBER` → `VERCEL_GIT_PULL_REQUEST_ID` in `next.config.ts` and `ChatInterface.tsx`.
+
+**Why**: `VERCEL_GIT_PULL_REQUEST_NUMBER` is not a real Vercel system env var. The correct name is `VERCEL_GIT_PULL_REQUEST_ID`. Without this fix the PR badge in the header would never render on preview deployments.
+
+---
+
 ### 2026-03-14 — Show PR link in header for deploy previews
 
 **What changed**: On Vercel preview deployments, the top header now displays a linked `#N` badge right after "Primordia", pointing to the GitHub PR for that preview. Production deployments are unaffected.

--- a/components/ChatInterface.tsx
+++ b/components/ChatInterface.tsx
@@ -348,14 +348,14 @@ export default function ChatInterface() {
           <h1 className="text-xl font-bold tracking-tight text-white flex items-baseline gap-2">
             Primordia
             {process.env.VERCEL_ENV === "preview" &&
-              process.env.VERCEL_GIT_PULL_REQUEST_NUMBER && (
+              process.env.VERCEL_GIT_PULL_REQUEST_ID && (
                 <a
-                  href={`https://github.com/${process.env.VERCEL_GIT_REPO_OWNER}/${process.env.VERCEL_GIT_REPO_SLUG}/pull/${process.env.VERCEL_GIT_PULL_REQUEST_NUMBER}`}
+                  href={`https://github.com/${process.env.VERCEL_GIT_REPO_OWNER}/${process.env.VERCEL_GIT_REPO_SLUG}/pull/${process.env.VERCEL_GIT_PULL_REQUEST_ID}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-sm font-normal text-blue-400 hover:text-blue-300"
                 >
-                  #{process.env.VERCEL_GIT_PULL_REQUEST_NUMBER}
+                  #{process.env.VERCEL_GIT_PULL_REQUEST_ID}
                 </a>
               )}
           </h1>

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,7 +5,7 @@ const nextConfig: NextConfig = {
   // Next.js inlines `env` values at build time, so they work in "use client" code.
   env: {
     VERCEL_ENV: process.env.VERCEL_ENV ?? "",
-    VERCEL_GIT_PULL_REQUEST_NUMBER: process.env.VERCEL_GIT_PULL_REQUEST_NUMBER ?? "",
+    VERCEL_GIT_PULL_REQUEST_ID: process.env.VERCEL_GIT_PULL_REQUEST_ID ?? "",
     VERCEL_GIT_REPO_OWNER: process.env.VERCEL_GIT_REPO_OWNER ?? "",
     VERCEL_GIT_REPO_SLUG: process.env.VERCEL_GIT_REPO_SLUG ?? "",
   },


### PR DESCRIPTION
On preview deploys, display a linked #N badge right after "Primordia" in the top header so each preview tab is easy to identify. Production deployments are unaffected.

Closes #15

Generated with [Claude Code](https://claude.ai/code