### PR TITLE
Refactor Python URL parsing to single-line commands

### DIFF
--- a/.github/workflows/evolve.yml
+++ b/.github/workflows/evolve.yml
@@ -73,16 +73,8 @@ jobs:
             --jq '[.comments[].body | scan("https://[^)]+quick_pull=1[^)]*")] | last')
 
           if [ -n "$COMPARE_URL" ]; then
-            PR_TITLE=$(python3 -c "
-import sys, urllib.parse
-qs = urllib.parse.urlparse('$COMPARE_URL').query
-print(urllib.parse.parse_qs(qs).get('title', [''])[0])
-")
-            PR_BODY=$(python3 -c "
-import sys, urllib.parse
-qs = urllib.parse.urlparse('$COMPARE_URL').query
-print(urllib.parse.parse_qs(qs).get('body', [''])[0])
-")
+            PR_TITLE=$(python3 -c "import urllib.parse; qs = urllib.parse.urlparse('$COMPARE_URL').query; print(urllib.parse.parse_qs(qs).get('title', [''])[0])")
+            PR_BODY=$(python3 -c "import urllib.parse; qs = urllib.parse.urlparse('$COMPARE_URL').query; print(urllib.parse.parse_qs(qs).get('body', [''])[0])")
           fi
 
           # Fall back to a generic title/body if parsing failed


### PR DESCRIPTION
## Summary
Simplified the GitHub Actions workflow by condensing multi-line Python commands into single-line equivalents for improved readability and maintainability.

## Key Changes
- Converted multi-line Python scripts for extracting `title` and `body` query parameters into single-line commands
- Removed unnecessary `sys` import that was not being used
- Maintained identical functionality while reducing code verbosity

## Implementation Details
The refactoring consolidates the URL parsing logic from 5 lines per variable down to 1 line, making the workflow file more concise without changing the behavior. Both the original and refactored versions:
- Parse the query string from `COMPARE_URL`
- Extract the `title` and `body` parameters
- Fall back to empty strings if parameters are not present

https://claude.ai/code/session_01UEN3W8TqaF8hbDh1ci1AyD