### PR TITLE
feat: make "Primordia" header text a link to the production app

### DIFF
--- a/PRIMORDIA.md
+++ b/PRIMORDIA.md
@@ -161,6 +161,14 @@ These were noted at project inception but are explicitly out of scope for the MV
 
 ## Changelog
 
+### 2026-03-14 — Make "Primordia" header text a link to the production app
+
+**What changed**: `next.config.ts` now exposes `VERCEL_PROJECT_PRODUCTION_URL` to client components. `components/ChatInterface.tsx`: the "Primordia" h1 text is now wrapped in an `<a>` tag (when the production URL is available) pointing to `https://${VERCEL_PROJECT_PRODUCTION_URL}` with `target="_blank"`. Styled with `text-white no-underline hover:text-gray-300` to preserve the same appearance as the plain text.
+
+**Why**: Gives users on deployment previews a one-click way to jump to the production app without the link looking like an obvious URL or button.
+
+---
+
 ### 2026-03-14 — Simplify deploy preview banner (hide PR details from visible notice)
 
 **What changed**: `components/ChatInterface.tsx`: the visible system message shown at the top of the chat on deploy previews now always displays only "⚠️ This is a deploy preview — a work-in-progress build, not the production app." The full PR/issue context string is still sent to Claude via `systemContext` so the assistant remains aware of it.

--- a/components/ChatInterface.tsx
+++ b/components/ChatInterface.tsx
@@ -562,7 +562,18 @@ export default function ChatInterface() {
       <header className="flex items-center justify-between mb-6 flex-shrink-0">
         <div>
           <h1 className="text-xl font-bold tracking-tight text-white flex items-baseline gap-2">
-            Primordia
+            {process.env.VERCEL_PROJECT_PRODUCTION_URL ? (
+              <a
+                href={`https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-white no-underline hover:text-gray-300"
+              >
+                Primordia
+              </a>
+            ) : (
+              "Primordia"
+            )}
             {process.env.VERCEL_ENV === "preview" &&
               process.env.VERCEL_GIT_PULL_REQUEST_ID && (
                 <a

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,8 @@ const nextConfig: NextConfig = {
     VERCEL_GIT_PULL_REQUEST_ID: process.env.VERCEL_GIT_PULL_REQUEST_ID ?? "",
     VERCEL_GIT_REPO_OWNER: process.env.VERCEL_GIT_REPO_OWNER ?? "",
     VERCEL_GIT_REPO_SLUG: process.env.VERCEL_GIT_REPO_SLUG ?? "",
+    VERCEL_PROJECT_PRODUCTION_URL:
+      process.env.VERCEL_PROJECT_PRODUCTION_URL ?? "",
   },
 };
 


### PR DESCRIPTION
Makes the "Primordia" h1 text a clickable link to the production app on Vercel deployments, same appearance as before.

Closes #34

Generated with [Claude Code](https://claude.ai/code