### PR TITLE
feat: filter evolve issue search to related issues only

### DIFF
--- a/PRIMORDIA.md
+++ b/PRIMORDIA.md
@@ -207,6 +207,7 @@ These were noted at project inception but are explicitly out of scope for the MV
 
 > Detailed changelog entries live in `changelog/`. Each file is named `YYYY-MM-DD-HH-MM-SS Description.md`; the filename is the short description and the body has the full what+why detail. The auto-generated `/changelog` page is built from these files at build time.
 
+- 2026-03-16 — Filter evolve issue search to related issues only → `changelog/2026-03-16-20-43-00 Filter evolve issue search to related issues only.md`
 - 2026-03-16 — Switch to file-based changelog system → `changelog/2026-03-16-00-03-00 Switch to file-based changelog system.md`
 - 2026-03-15 — Local evolve flow now uses `@anthropic-ai/claude-agent-sdk` → `changelog/2026-03-15-00-01-00 Local evolve flow now uses claude-agent-sdk.md`
 - 2026-03-14 — (20 earlier entries) Initial scaffold through various fixes and improvements → see `changelog/`

--- a/app/api/evolve/route.ts
+++ b/app/api/evolve/route.ts
@@ -36,10 +36,14 @@ export async function POST(request: Request) {
 
   const action = body.action ?? "create";
 
-  // ── Search: find open evolve issues ────────────────────────────────────────
+  // ── Search: find open evolve issues related to the request ─────────────────
   if (action === "search") {
     try {
-      const issues = await searchOpenEvolveIssues({ token, repo });
+      const issues = await searchOpenEvolveIssues({
+        token,
+        repo,
+        request: body.request ?? "",
+      });
       return Response.json({ issues });
     } catch (err) {
       const msg =
@@ -224,17 +228,35 @@ async function findOpenPrForIssue({
   return prs.find((p) => p.head.ref.includes(`issue-${issueNumber}-`)) ?? null;
 }
 
+// Extract meaningful keywords from a freeform request string.
+// Filters out short words (≤ 3 chars) and limits to the first 6 keywords so
+// the GitHub Search query stays concise.
+function extractKeywords(request: string): string {
+  return request
+    .replace(/[^\w\s]/g, " ")
+    .split(/\s+/)
+    .filter((word) => word.length > 3)
+    .slice(0, 6)
+    .join(" ");
+}
+
 async function searchOpenEvolveIssues({
   token,
   repo,
+  request,
 }: {
   token: string;
   repo: string;
+  request: string;
 }): Promise<OpenIssue[]> {
-  // Search for open issues whose title starts with the evolve prefix
-  const q = encodeURIComponent(
-    `repo:${repo} is:issue state:open "[Primordia Evolve]" in:title`
-  );
+  // Build a query that requires the evolve prefix in the title AND matches
+  // keywords extracted from the user's request anywhere in the issue.
+  // This narrows results to issues that are actually related to the request.
+  const keywords = extractKeywords(request);
+  const queryText = keywords
+    ? `repo:${repo} is:issue state:open "[Primordia Evolve]" in:title ${keywords}`
+    : `repo:${repo} is:issue state:open "[Primordia Evolve]" in:title`;
+  const q = encodeURIComponent(queryText);
   const url = `https://api.github.com/search/issues?q=${q}&sort=created&order=desc&per_page=5`;
 
   const response = await fetch(url, {

--- a/changelog/2026-03-16-20-43-00 Filter evolve issue search to related issues only.md
+++ b/changelog/2026-03-16-20-43-00 Filter evolve issue search to related issues only.md
@@ -1,0 +1,6 @@
+Filter open evolve issue search to only return issues related to the current request, and auto-create a new issue when none match.
+
+**What changed**:
+- `app/api/evolve/route.ts`: added `extractKeywords(request)` helper that strips punctuation, filters words ≤ 3 characters, and takes the first 6 keywords. `searchOpenEvolveIssues` now accepts a `request` parameter and appends those keywords to the GitHub search query, narrowing results to issues whose title/body/comments overlap with the user's request. The `search` action handler passes `body.request` through to the function.
+
+**Why**: Previously, searching for open evolve issues returned every open `[Primordia Evolve]` issue, flooding the decision card with unrelated entries. With keyword-based filtering, only genuinely related issues are returned. When no related issues exist the frontend already falls through to auto-creating a new issue — so the decision prompt is now suppressed for truly new requests.


### PR DESCRIPTION
Fixes #41

Only return open evolve issues that are related to the current evolve request, using keyword extraction against the GitHub Search API. Auto-create a new issue when no related issues are found, skipping the decision prompt.

Generated with [Claude Code](https://claude.ai/code