### PR TITLE
fix: use dvh unit for correct mobile viewport height

### DIFF
--- a/changelog/2026-03-17-22-54-00 Fix mobile viewport height using dvh unit.md
+++ b/changelog/2026-03-17-22-54-00 Fix mobile viewport height using dvh unit.md
@@ -1,0 +1,9 @@
+# Fix mobile viewport height using dvh unit
+
+## What changed
+Replaced `h-screen` (`height: 100vh`) with `h-dvh` (`height: 100dvh`) on the main chat container in `components/ChatInterface.tsx`.
+
+## Why
+On mobile browsers, `100vh` is calculated based on the full viewport height without browser chrome (address bar, on-screen keyboard). When the address bar is visible or the virtual keyboard is open, the actual visible area is smaller, causing the layout to overflow or clip incorrectly.
+
+The CSS `dvh` (dynamic viewport height) unit adjusts dynamically as the browser UI appears and disappears, so `100dvh` always equals the current visible viewport height. Tailwind CSS v3.4+ ships `h-dvh` out of the box.

--- a/components/ChatInterface.tsx
+++ b/components/ChatInterface.tsx
@@ -772,7 +772,7 @@ export default function ChatInterface() {
   // ── Render ────────────────────────────────────────────────────────────────
 
   return (
-    <main className="flex flex-col w-full max-w-3xl h-screen mx-auto px-4 py-6">
+    <main className="flex flex-col w-full max-w-3xl h-dvh mx-auto px-4 py-6">
       {/* Header */}
       <header className="flex items-center justify-between mb-6 flex-shrink-0">
         <div>


### PR DESCRIPTION
Replace `h-screen` (100vh) with `h-dvh` (100dvh) on the main chat container so the layout fits the visible area correctly when the address bar or on-screen keyboard is shown on mobile browsers.

Closes #56

Generated with [Claude Code](https://claude.ai/code)