### PR TITLE
feat: fall back to branch-based PR lookup when VERCEL_GIT_PULL_REQUEST_ID is empty

### DIFF
--- a/app/api/deploy-context/route.ts
+++ b/app/api/deploy-context/route.ts
@@ -4,12 +4,18 @@
 // pre-loaded with "works-in-progress" context.
 //
 // Response (JSON):
-//   { context: string | null }
+//   { context: string | null, prNumber?: number, prUrl?: string, prState?: "open" | "closed" | "merged" }
 //
-// Returns null when:
-//   - VERCEL_GIT_PULL_REQUEST_ID is not set (i.e. production or local)
+// Returns null context when:
+//   - Not a preview branch (i.e. this is production or local)
 //   - Required GITHUB_TOKEN / GITHUB_REPO env vars are missing
 //   - GitHub API requests fail
+//   - No PR is found (branch push before PR creation, and no PR exists yet)
+//
+// PR lookup strategy:
+//   1. If VERCEL_GIT_PULL_REQUEST_ID is set, use it directly.
+//   2. If it is empty (deploy created before PR was opened) and branch is not
+//      "main", search for a PR by branch name via the GitHub API.
 //
 // Required environment variables:
 //   GITHUB_TOKEN  — personal access token with repo read access
@@ -20,6 +26,8 @@ interface GitHubPR {
   title: string;
   body: string;
   html_url: string;
+  state: "open" | "closed";
+  merged_at: string | null;
   head: { ref: string };
 }
 
@@ -29,13 +37,21 @@ interface GitHubIssue {
   html_url: string;
 }
 
+type PRState = "open" | "closed" | "merged";
+
+function getPRState(pr: GitHubPR): PRState {
+  if (pr.merged_at) return "merged";
+  if (pr.state === "closed") return "closed";
+  return "open";
+}
+
 export async function GET() {
   const prId = process.env.VERCEL_GIT_PULL_REQUEST_ID;
   const token = process.env.GITHUB_TOKEN;
   const repo = process.env.GITHUB_REPO;
+  const branch = process.env.VERCEL_GIT_COMMIT_REF;
 
-  // Only meaningful when there's a PR ID (preview deployments)
-  if (!prId || !token || !repo) {
+  if (!token || !repo) {
     return Response.json({ context: null });
   }
 
@@ -45,20 +61,41 @@ export async function GET() {
     "X-GitHub-Api-Version": "2022-11-28",
   };
 
-  // ── 1. Fetch the PR ────────────────────────────────────────────────────────
+  let pr: GitHubPR | null = null;
 
-  const prRes = await fetch(
-    `https://api.github.com/repos/${repo}/pulls/${prId}`,
-    { headers }
-  );
+  if (prId) {
+    // ── Strategy 1: PR ID is known — fetch directly ────────────────────────
+    const prRes = await fetch(
+      `https://api.github.com/repos/${repo}/pulls/${prId}`,
+      { headers }
+    );
+    if (!prRes.ok) {
+      return Response.json({ context: null });
+    }
+    pr = (await prRes.json()) as GitHubPR;
+  } else if (branch && branch !== "main" && branch !== "master") {
+    // ── Strategy 2: No PR ID yet — look up PR by branch name ──────────────
+    // This happens when Vercel deploys a branch push before any PR is opened.
+    const owner = repo.split("/")[0];
+    const searchRes = await fetch(
+      `https://api.github.com/repos/${repo}/pulls?head=${encodeURIComponent(owner)}:${encodeURIComponent(branch)}&state=all&per_page=1`,
+      { headers }
+    );
+    if (searchRes.ok) {
+      const prs = (await searchRes.json()) as GitHubPR[];
+      if (prs.length > 0) {
+        pr = prs[0];
+      }
+    }
+  }
 
-  if (!prRes.ok) {
+  if (!pr) {
     return Response.json({ context: null });
   }
 
-  const pr = (await prRes.json()) as GitHubPR;
+  const prState = getPRState(pr);
 
-  // ── 2. Find the linked issue from the PR body ──────────────────────────────
+  // ── Find the linked issue from the PR body ─────────────────────────────────
   // Looks for "Closes #N", "Fixes #N", "Resolves #N" (case-insensitive).
 
   let issue: GitHubIssue | null = null;
@@ -73,11 +110,15 @@ export async function GET() {
     }
   }
 
-  // ── 3. Build the context string ────────────────────────────────────────────
+  // ── Build the context string ───────────────────────────────────────────────
+
+  const stateLabel =
+    prState === "merged" ? " ✅ merged" :
+    prState === "closed" ? " 🗑️ closed" : "";
 
   const lines: string[] = [
     `⚠️ This is a **deploy preview** — a work-in-progress build, not the production app.`,
-    `**PR [#${pr.number}](${pr.html_url})**: ${pr.title} (branch: \`${pr.head.ref}\`)`,
+    `**PR [#${pr.number}](${pr.html_url})**: ${pr.title} (branch: \`${pr.head.ref}\`)${stateLabel}`,
   ];
 
   if (issue) {
@@ -86,5 +127,10 @@ export async function GET() {
     );
   }
 
-  return Response.json({ context: lines.join("\n"), prNumber: pr.number, prUrl: pr.html_url });
+  return Response.json({
+    context: lines.join("\n"),
+    prNumber: pr.number,
+    prUrl: pr.html_url,
+    prState,
+  });
 }

--- a/changelog/2026-03-20-04-22-00 Fall back to branch-based PR lookup and show PR state in deploy preview bar.md
+++ b/changelog/2026-03-20-04-22-00 Fall back to branch-based PR lookup and show PR state in deploy preview bar.md
@@ -1,0 +1,19 @@
+# Fall back to branch-based PR lookup and show PR state in deploy preview bar
+
+## What changed
+
+### `app/api/deploy-context/route.ts`
+- When `VERCEL_GIT_PULL_REQUEST_ID` is empty (Vercel deployed the branch before a PR was opened) and the branch is not `main`/`master`, the endpoint now searches for an associated PR by branch name using the GitHub API (`/pulls?head={owner}:{branch}&state=all`).
+- A new `prState` field (`"open" | "closed" | "merged"`) is returned in the response alongside the existing `prNumber` and `prUrl`.
+- The `GitHubPR` interface now includes `state` and `merged_at` fields.
+
+### `components/ChatInterface.tsx`
+- A new `deployPrState` state variable tracks the PR's current state.
+- The Vercel preview accept/reject bar now behaves differently based on `prState`:
+  - **`"merged"`**: Shows a notice that the PR is already merged (no accept/reject buttons).
+  - **`"closed"`**: Shows a notice that the PR was already closed/discarded (no accept/reject buttons).
+  - **`"open"` or unknown**: Shows the normal accept/reject buttons as before.
+
+## Why
+
+When Vercel creates a deployment for a branch push that happens before a PR is made, `VERCEL_GIT_PULL_REQUEST_ID` is an empty string. Previously, the deploy-context API returned `null` in this case, so the preview bar and PR context were never shown. This fix ensures the PR is still found (if one was later opened) and the UI correctly reflects the PR's current state — avoiding presenting accept/reject actions when the PR is already resolved.

--- a/components/ChatInterface.tsx
+++ b/components/ChatInterface.tsx
@@ -114,6 +114,8 @@ export default function ChatInterface({ branch, commitMessage, isPreviewInstance
   const [deployContext, setDeployContext] = useState<string | null>(null);
   // PR number for the current deploy preview (null on production/local builds).
   const [deployPrNumber, setDeployPrNumber] = useState<number | null>(null);
+  // PR state for the current deploy preview ("open", "closed", or "merged").
+  const [deployPrState, setDeployPrState] = useState<"open" | "closed" | "merged" | null>(null);
   // Action state for the Vercel preview accept/reject bar.
   const [vercelActionState, setVercelActionState] = useState<"idle" | "loading" | "accepted" | "rejected">("idle");
   // Decision state: shown when related open issues are found before creating a new one
@@ -197,10 +199,11 @@ export default function ChatInterface({ branch, commitMessage, isPreviewInstance
 
     fetch("/api/deploy-context")
       .then((res) => res.json())
-      .then((data: { context: string | null; prNumber?: number; prUrl?: string }) => {
+      .then((data: { context: string | null; prNumber?: number; prUrl?: string; prState?: "open" | "closed" | "merged" }) => {
         if (!data.context) return;
         setDeployContext(data.context);
         if (data.prNumber) setDeployPrNumber(data.prNumber);
+        if (data.prState) setDeployPrState(data.prState);
         // Prepend a visible system message so the context is front-and-centre.
         // Show only a brief notice; the full PR/issue context is sent to Claude via systemContext.
         setMessages((prev) => [
@@ -952,7 +955,17 @@ export default function ChatInterface({ branch, commitMessage, isPreviewInstance
       )}
 
       {/* Vercel preview accept/reject bar — shown on Vercel deploy preview deployments */}
-      {deployPrNumber !== null && vercelActionState !== "accepted" && vercelActionState !== "rejected" && (
+      {deployPrNumber !== null && deployPrState === "merged" && vercelActionState !== "accepted" && (
+        <div className="mb-3 px-4 py-3 rounded-lg bg-green-900/30 border border-green-700/40 text-sm flex-shrink-0">
+          <p className="text-green-200">✅ PR #{deployPrNumber} has already been merged. These changes are live in production.</p>
+        </div>
+      )}
+      {deployPrNumber !== null && deployPrState === "closed" && vercelActionState !== "rejected" && (
+        <div className="mb-3 px-4 py-3 rounded-lg bg-red-900/30 border border-red-700/40 text-sm flex-shrink-0">
+          <p className="text-red-200">🗑️ PR #{deployPrNumber} has already been closed. These changes were discarded.</p>
+        </div>
+      )}
+      {deployPrNumber !== null && (deployPrState === "open" || deployPrState === null) && vercelActionState !== "accepted" && vercelActionState !== "rejected" && (
         <div className="mb-3 px-4 py-3 rounded-lg bg-green-900/30 border border-green-700/40 text-sm flex-shrink-0 space-y-3">
           <p className="text-green-200 font-semibold">
             🔍 This is a preview of PR #{deployPrNumber} — review the changes, then accept or reject.


### PR DESCRIPTION
When Vercel deploys a branch before a PR is created, VERCEL_GIT_PULL_REQUEST_ID is an empty string. This PR makes the deploy-context API search for a PR by branch name in that case, and returns the PR state so the accept/reject bar can correctly reflect it.

Closes #75

Generated with [Claude Code](https://claude.ai/code