### PR TITLE
Remove inaccurate "Production deployment is on its way!" message

### DIFF
--- a/changelog/2026-03-20-14-30-00 Remove inaccurate production deployment message.md
+++ b/changelog/2026-03-20-14-30-00 Remove inaccurate production deployment message.md
@@ -1,0 +1,9 @@
+# Remove inaccurate "Production deployment is on its way!" message
+
+## What changed
+
+Removed the phrase "Production deployment is on its way!" from the accepted-changes confirmation message in `components/ChatInterface.tsx`.
+
+## Why
+
+The message was misleading. It claimed a production deployment was happening whenever a PR was merged, but that's only true if the target branch is `main`. In a hyperforkable app like Primordia where branches can be anything, the notion of "production" is ambiguous. The simpler message — "✅ Changes accepted and merged into `{branch}`." — is accurate in all cases.

--- a/components/ChatInterface.tsx
+++ b/components/ChatInterface.tsx
@@ -1007,7 +1007,7 @@ export default function ChatInterface({ branch, commitMessage, isPreviewInstance
       )}
       {deployPrNumber !== null && vercelActionState === "accepted" && (
         <div className="mb-3 px-4 py-3 rounded-lg bg-green-900/30 border border-green-700/40 text-sm flex-shrink-0">
-          <p className="text-green-200">✅ Changes accepted and merged into <code className="bg-green-900/50 px-1 rounded">{deployPrBaseBranch}</code>. Production deployment is on its way!</p>
+          <p className="text-green-200">✅ Changes accepted and merged into <code className="bg-green-900/50 px-1 rounded">{deployPrBaseBranch}</code>.</p>
         </div>
       )}
       {deployPrNumber !== null && vercelActionState === "rejected" && (


### PR DESCRIPTION
Removes the inaccurate "Production deployment is on its way!" text from the accepted-changes confirmation banner. The message was only accurate when merging to main, and in a hyperforkable app "production" is ambiguous anyway.

Closes #85

Generated with [Claude Code](https://claude.ai/code)