### PR TITLE
Remove "production" from deployment message

### DIFF
--- a/changelog/2026-03-20-14-36-00 Remove production from deployment message.md
+++ b/changelog/2026-03-20-14-36-00 Remove production from deployment message.md
@@ -1,0 +1,13 @@
+# Remove "production" from deployment message
+
+## What changed
+Updated the post-merge deployment message in `components/ChatInterface.tsx` from:
+
+> "The changes will be deployed to production shortly."
+
+to:
+
+> "The changes will be deployed shortly."
+
+## Why
+The word "production" is inaccurate in the context of deploy previews, where merging a PR doesn't necessarily mean deploying to production. Removing it makes the message more universally correct.

--- a/components/ChatInterface.tsx
+++ b/components/ChatInterface.tsx
@@ -756,7 +756,7 @@ export default function ChatInterface({ branch, commitMessage, isPreviewInstance
         ...prev,
         {
           role: "assistant",
-          content: `✅ PR #${deployPrNumber} has been merged! The changes will be deployed to production shortly.`,
+          content: `✅ PR #${deployPrNumber} has been merged! The changes will be deployed shortly.`,
         },
       ]);
     } catch (err) {


### PR DESCRIPTION
Removes the word "production" from the post-merge deployment message to make it accurate across all deploy contexts.

Closes #87

Generated with [Claude Code](https://claude.ai/code