### PR TITLE
feat: show most recent changelog entry as "Most recent change:" text

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,10 @@
 // app/page.tsx — The main entry point for Primordia
-// This is a React Server Component. It reads the current git branch and full
-// HEAD commit message at request time (no client-side fetches needed), then
-// passes them as props to the ChatInterface client component.
+// This is a React Server Component. It reads the current git branch and the
+// most recent changelog entry at request time (no client-side fetches needed),
+// then passes them as props to the ChatInterface client component.
 //
 // On Vercel deployments, built-in env vars are used:
-//   VERCEL_GIT_COMMIT_REF     — branch name
-//   VERCEL_GIT_COMMIT_MESSAGE — full commit message
+//   VERCEL_GIT_COMMIT_REF — branch name
 //
 // In local dev and git worktrees, falls back to running git commands directly.
 //
@@ -13,6 +12,8 @@
 // pages) and passed to AcceptRejectBar.
 
 import { execSync } from "child_process";
+import { readdirSync, readFileSync } from "fs";
+import { join } from "path";
 import ChatInterface from "@/components/ChatInterface";
 
 function runGit(cmd: string): string | null {
@@ -28,14 +29,32 @@ function runGit(cmd: string): string | null {
   }
 }
 
+// Matches: YYYY-MM-DD-HH-MM-SS Description of change.md
+const CHANGELOG_FILENAME_RE = /^(\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}) (.+)\.md$/;
+
+function getMostRecentChangelogEntry(): string | null {
+  try {
+    const changelogDir = join(process.cwd(), "changelog");
+    const files = readdirSync(changelogDir)
+      .filter((f) => CHANGELOG_FILENAME_RE.test(f))
+      .sort()
+      .reverse();
+    if (files.length === 0) return null;
+    const latest = files[0];
+    const m = latest.match(CHANGELOG_FILENAME_RE);
+    const title = m ? m[2] : latest.replace(/\.md$/, "");
+    const body = readFileSync(join(changelogDir, latest), "utf-8").trim();
+    return body ? `**${title}**\n\n${body}` : `**${title}**`;
+  } catch {
+    return null;
+  }
+}
+
 export default function Home() {
   const branch =
     process.env.VERCEL_GIT_COMMIT_REF ?? runGit("git branch --show-current");
 
-  // Use %B to get the full commit message (subject + body), not just the subject line.
-  const commitMessage =
-    process.env.VERCEL_GIT_COMMIT_MESSAGE ??
-    runGit("git log -1 --pretty=%B");
+  const commitMessage = getMostRecentChangelogEntry();
 
   return (
     <ChatInterface

--- a/changelog/2026-03-20-15-09-00 Show most recent changelog entry instead of git commit.md
+++ b/changelog/2026-03-20-15-09-00 Show most recent changelog entry instead of git commit.md
@@ -1,0 +1,10 @@
+# Show most recent changelog entry instead of git commit
+
+The "Most recent change:" message shown in the chat on startup now displays the
+most recent `changelog/` entry (title + full body) instead of the raw git commit
+message. This gives users a human-readable summary of what changed rather than
+an internal commit log line.
+
+`app/page.tsx` was updated to read the `changelog/` directory, sort files
+lexicographically (which equals chronological order given the filename convention),
+pick the newest file, and pass its title and body as the initial chat message.


### PR DESCRIPTION
Instead of the raw git commit message, show the most recent `changelog/` entry (title + body