### PR TITLE
Route Claude Code CLI subprocess through exe.dev gateway

### DIFF
--- a/lib/evolve-sessions.ts
+++ b/lib/evolve-sessions.ts
@@ -21,7 +21,6 @@ async function getGatewayEnv(): Promise<Record<string, string>> {
   if (await isGatewayAvailable()) {
     return {
       ANTHROPIC_BASE_URL: GATEWAY_BASE_URL,
-      ANTHROPIC_API_KEY: 'gateway',
     };
   }
   return {};

--- a/lib/evolve-sessions.ts
+++ b/lib/evolve-sessions.ts
@@ -9,6 +9,24 @@ import * as fs from 'fs';
 import { getDb } from './db';
 import { isGatewayAvailable } from './llm-client';
 
+const GATEWAY_BASE_URL = 'http://169.254.169.254/gateway/llm/anthropic';
+
+/**
+ * Returns env vars to inject into the Claude Code CLI subprocess so it routes
+ * through the exe.dev LLM gateway instead of calling Anthropic directly.
+ * Returns an empty object when the gateway is not available (falls back to
+ * whatever ANTHROPIC_API_KEY is set in the process environment).
+ */
+async function getGatewayEnv(): Promise<Record<string, string>> {
+  if (await isGatewayAvailable()) {
+    return {
+      ANTHROPIC_BASE_URL: GATEWAY_BASE_URL,
+      ANTHROPIC_API_KEY: 'gateway',
+    };
+  }
+  return {};
+}
+
 export type LocalSessionStatus =
   | 'starting'
   | 'running-claude'
@@ -411,6 +429,7 @@ export async function startLocalEvolve(
       prompt,
       options: {
         cwd: session.worktreePath,
+        env: await getGatewayEnv(),
         systemPrompt: {
           type: 'preset',
           preset: 'claude_code',
@@ -732,6 +751,7 @@ export async function runFollowupInWorktree(
       prompt,
       options: {
         cwd: session.worktreePath,
+        env: await getGatewayEnv(),
         systemPrompt: {
           type: 'preset',
           preset: 'claude_code',
@@ -1015,6 +1035,7 @@ export async function resolveConflictsWithClaude(
       prompt,
       options: {
         cwd: mergeRoot,
+        env: await getGatewayEnv(),
         systemPrompt: {
           type: 'preset',
           preset: 'claude_code',


### PR DESCRIPTION
The query() calls in evolve-sessions.ts spawn the claude CLI as a
subprocess which reads its API key from the environment, bypassing
getLlmClient(). Inject ANTHROPIC_BASE_URL and ANTHROPIC_API_KEY=gateway
into the subprocess env when the exe.dev gateway is available, so the
CLI routes through the gateway instead of failing with "not logged in".

https://claude.ai/code/session_014eWymvYtRs2KXdQdYTUhPy